### PR TITLE
Add support for Shopify API version 2019-10

### DIFF
--- a/src/Api/Endpoint/AbstractEndpoint.php
+++ b/src/Api/Endpoint/AbstractEndpoint.php
@@ -3,6 +3,7 @@ namespace CodeCloud\Bundle\ShopifyBundle\Api\Endpoint;
 
 use CodeCloud\Bundle\ShopifyBundle\Api\Request\Exception\FailedRequestException;
 use CodeCloud\Bundle\ShopifyBundle\Api\GenericResource;
+use CodeCloud\Bundle\ShopifyBundle\Api\Response\ResponseInterface;
 use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use CodeCloud\Bundle\ShopifyBundle\Api\Response\ErrorResponse;
@@ -34,7 +35,7 @@ abstract class AbstractEndpoint
 
     /**
      * @param RequestInterface $request
-     * @return \CodeCloud\Bundle\ShopifyBundle\Api\Response\ResponseInterface
+     * @return ResponseInterface
      * @throws FailedRequestException
      */
     protected function send(RequestInterface $request)
@@ -51,12 +52,13 @@ abstract class AbstractEndpoint
     /**
      * @param RequestInterface $request
      * @param string $rootElement
+     * @param array $links
      * @return array
      * @throws FailedRequestException
      */
-    protected function sendPaged(RequestInterface $request, $rootElement)
+    protected function sendPaged(RequestInterface $request, $rootElement, array &$links = array())
     {
-        return $this->processPaged($request, $rootElement);
+        return $this->processPaged($request, $rootElement, array(), $links);
     }
 
     /**
@@ -95,7 +97,7 @@ abstract class AbstractEndpoint
 
     /**
      * @param RequestInterface $request
-     * @return \CodeCloud\Bundle\ShopifyBundle\Api\Response\ResponseInterface
+     * @return ResponseInterface
      */
     protected function process(RequestInterface $request)
     {
@@ -121,9 +123,10 @@ abstract class AbstractEndpoint
      * @param RequestInterface $request
      * @param string $rootElement
      * @param array $params
+     * @param array $links
      * @return array
      */
-    protected function processPaged(RequestInterface $request, $rootElement, array $params = array())
+    protected function processPaged(RequestInterface $request, $rootElement, array $params = array(), array &$links = array())
     {
         $requestUrl = $request->getUri();
 
@@ -133,6 +136,7 @@ abstract class AbstractEndpoint
             parse_str($parts['query'], $query);
             if (array_key_exists('limit', $query)) {
                 $response = $this->process($request->withUri(new Uri($requestUrl)));
+                $links = $this->parseLinks($response);
                 return $response->get($rootElement);
             }
         }
@@ -166,5 +170,24 @@ abstract class AbstractEndpoint
         } while ($nextLink);
 
         return $allResults;
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @return array
+     */
+    protected function parseLinks(ResponseInterface $response)
+    {
+        $header = $response->getHttpResponse()->getHeaderLine('Link');
+        $headerParts = explode(',', $header);
+
+        $links = [];
+        foreach ( $headerParts as $part) {
+            if (preg_match('/<(.*)>; rel="(.*)"/', $part, $parsedHeader)) {
+                $links[$parsedHeader[2]] = $parsedHeader[1];
+            }
+        }
+
+        return $links;
     }
 }

--- a/src/Api/Endpoint/ApplicationChargeEndpoint.php
+++ b/src/Api/Endpoint/ApplicationChargeEndpoint.php
@@ -13,7 +13,7 @@ class ApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetParams('/admin/application_charges.json', $query);
+        $request = new GetParams('/admin/api/' . $this->version . '/application_charges.json', $query);
         $response = $this->send($request);
         return $this->createCollection($response->get('application_charges'));
     }
@@ -24,7 +24,7 @@ class ApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function findOne($applicationChargeId)
     {
-        $request = new GetParams('/admin/application_charges/' . $applicationChargeId . '.json');
+        $request = new GetParams('/admin/api/' . $this->version . '/application_charges/' . $applicationChargeId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('application_charge'));
     }
@@ -35,7 +35,7 @@ class ApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $applicationCharge)
     {
-        $request = new PostJson('/admin/application_charges.json', array('application_charge' => $applicationCharge->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/application_charges.json', array('application_charge' => $applicationCharge->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('application_charge'));
     }
@@ -45,7 +45,7 @@ class ApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function activate($applicationChargeId)
     {
-        $request = new PostJson('/admin/application_charges/' . $applicationChargeId . '/activate.json', null);
+        $request = new PostJson('/admin/api/' . $this->version . '/application_charges/' . $applicationChargeId . '/activate.json', null);
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/ArticleEndpoint.php
+++ b/src/Api/Endpoint/ArticleEndpoint.php
@@ -16,7 +16,7 @@ class ArticleEndpoint extends AbstractEndpoint
      */
     public function findByBlog($blogId, array $query = array())
     {
-        $request = new GetJson('/admin/blogs/' . $blogId . '/articles.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/blogs/' . $blogId . '/articles.json', $query);
         $response = $this->sendPaged($request, 'articles');
         return $this->createCollection($response);
     }
@@ -28,7 +28,7 @@ class ArticleEndpoint extends AbstractEndpoint
      */
     public function countByBlog($blogId, array $query = array())
     {
-        $request = new GetJson('/admin/blogs/' . $blogId . '/articles/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/blogs/' . $blogId . '/articles/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -40,7 +40,7 @@ class ArticleEndpoint extends AbstractEndpoint
      */
     public function findOne($blogId, $articleId)
     {
-        $request = new GetJson('/admin/blogs/' . $blogId . '/articles/' . $articleId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/blogs/' . $blogId . '/articles/' . $articleId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('article'));
     }
@@ -52,7 +52,7 @@ class ArticleEndpoint extends AbstractEndpoint
      */
     public function create($blogId, GenericResource $article)
     {
-        $request = new PostJson('/admin/blogs/' . $blogId . '/articles.json', array('article' => $article->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/blogs/' . $blogId . '/articles.json', array('article' => $article->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('article'));
     }
@@ -65,7 +65,7 @@ class ArticleEndpoint extends AbstractEndpoint
      */
     public function update($blogId, $articleId, GenericResource $article)
     {
-        $request = new PutJson('/admin/blogs/' . $blogId . '/articles/' . $articleId . '.json', array('article' => $article->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/blogs/' . $blogId . '/articles/' . $articleId . '.json', array('article' => $article->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('article'));
     }
@@ -76,7 +76,7 @@ class ArticleEndpoint extends AbstractEndpoint
      */
     public function delete($blogId, $articleId)
     {
-        $request = new DeleteParams('/admin/blogs/' . $blogId . '/articles/' . $articleId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/blogs/' . $blogId . '/articles/' . $articleId . '.json');
         $this->send($request);
     }
 
@@ -85,7 +85,7 @@ class ArticleEndpoint extends AbstractEndpoint
      */
     public function findAllAuthors()
     {
-        $request = new GetJson('/admin/articles/authors.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/articles/authors.json');
         $response = $this->send($request);
         return $response->get('authors');
     }
@@ -96,7 +96,7 @@ class ArticleEndpoint extends AbstractEndpoint
      */
     public function findAllTags(array $query = array())
     {
-        $request = new GetJson('/admin/articles/tags.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/articles/tags.json', $query);
         $response = $this->send($request);
         return $response->get('tags');
     }

--- a/src/Api/Endpoint/ArticleEndpoint.php
+++ b/src/Api/Endpoint/ArticleEndpoint.php
@@ -12,12 +12,13 @@ class ArticleEndpoint extends AbstractEndpoint
     /**
      * @param int $blogId
      * @param array $query
+     * @param array $links
      * @return array
      */
-    public function findByBlog($blogId, array $query = array())
+    public function findByBlog($blogId, array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/blogs/' . $blogId . '/articles.json', $query);
-        $response = $this->sendPaged($request, 'articles');
+        $response = $this->sendPaged($request, 'articles', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/AssetEndpoint.php
+++ b/src/Api/Endpoint/AssetEndpoint.php
@@ -15,7 +15,7 @@ class AssetEndpoint extends AbstractEndpoint
             $params['fields'] = implode(',', $fields);
         }
 
-        $request = new GetJson('/admin/themes/' . $themeId . '/assets.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/themes/' . $themeId . '/assets.json', $params);
         $response = $this->send($request);
         return $response->get('assets');
     }
@@ -32,7 +32,7 @@ class AssetEndpoint extends AbstractEndpoint
             'theme_id'   => $themeId
         );
 
-        $request = new GetJson('/admin/themes/' . $themeId . '/assets.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/themes/' . $themeId . '/assets.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('asset'));
     }
@@ -52,7 +52,7 @@ class AssetEndpoint extends AbstractEndpoint
             )
         );
 
-        $request = new PutJson('/admin/themes/' . $themeId . '/assets.json', $params);
+        $request = new PutJson('/admin/api/' . $this->version . '/themes/' . $themeId . '/assets.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('asset'));
     }
@@ -72,7 +72,7 @@ class AssetEndpoint extends AbstractEndpoint
             )
         );
 
-        $request = new PutJson('/admin/themes/' . $themeId . '/assets.json', $params);
+        $request = new PutJson('/admin/api/' . $this->version . '/themes/' . $themeId . '/assets.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('asset'));
     }
@@ -92,7 +92,7 @@ class AssetEndpoint extends AbstractEndpoint
             )
         );
 
-        $request = new PutJson('/admin/themes/' . $themeId . '/assets.json', $params);
+        $request = new PutJson('/admin/api/' . $this->version . '/themes/' . $themeId . '/assets.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('asset'));
     }
@@ -112,7 +112,7 @@ class AssetEndpoint extends AbstractEndpoint
             )
         );
 
-        $request = new PutJson('/admin/themes/' . $themeId . '/assets.json', $params);
+        $request = new PutJson('/admin/api/' . $this->version . '/themes/' . $themeId . '/assets.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('asset'));
     }
@@ -128,7 +128,7 @@ class AssetEndpoint extends AbstractEndpoint
             'theme_id'   => $themeId
         );
 
-        $request = new DeleteParams('/admin/themes/' . $themeId . '/assets.json', $params);
+        $request = new DeleteParams('/admin/api/' . $this->version . '/themes/' . $themeId . '/assets.json', $params);
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/BlogEndpoint.php
+++ b/src/Api/Endpoint/BlogEndpoint.php
@@ -37,7 +37,7 @@ class BlogEndpoint extends AbstractEndpoint
     public function findOne($blogId, array $fields = array())
     {
         $params = $fields ? array('fields' => $fields) : array();
-        $request = new GetJson('/admin/blogs/' . $blogId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/blogs/' . $blogId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('blog'));
     }
@@ -48,7 +48,7 @@ class BlogEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $blog)
     {
-        $request = new PostJson('/admin/blogs.json', array('blog' => $blog->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/blogs.json', array('blog' => $blog->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('blog'));
     }
@@ -60,7 +60,7 @@ class BlogEndpoint extends AbstractEndpoint
      */
     public function update($blogId, GenericResource $blog)
     {
-        $request = new PostJson('/admin/blogs/' . $blogId . '.json', array('blog' => $blog->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/blogs/' . $blogId . '.json', array('blog' => $blog->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('blog'));
     }
@@ -70,7 +70,7 @@ class BlogEndpoint extends AbstractEndpoint
      */
     public function delete($blogId)
     {
-        $request = new DeleteParams('/admin/blogs/' . $blogId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/blogs/' . $blogId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CarrierServiceEndpoint.php
+++ b/src/Api/Endpoint/CarrierServiceEndpoint.php
@@ -13,7 +13,7 @@ class CarrierServiceEndpoint extends AbstractEndpoint
      */
     public function findAll()
     {
-        $request = new GetJson('/admin/carrier_services.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/carrier_services.json');
         $response = $this->send($request);
         return $this->createCollection($response->get('carrier_services'));
     }
@@ -24,7 +24,7 @@ class CarrierServiceEndpoint extends AbstractEndpoint
      */
     public function findOne($carrierServiceId)
     {
-        $request = new GetJson('/admin/carrier_services/' . $carrierServiceId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/carrier_services/' . $carrierServiceId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('carrier_service'));
     }
@@ -35,7 +35,7 @@ class CarrierServiceEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $carrierService)
     {
-        $request = new PostJson('/admin/carrier_services.json', array('carrier_service' => $carrierService->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/carrier_services.json', array('carrier_service' => $carrierService->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('carrier_service'));
     }
@@ -47,7 +47,7 @@ class CarrierServiceEndpoint extends AbstractEndpoint
      */
     public function update($carrierServiceId, GenericResource $carrierService)
     {
-        $request = new PostJson('/admin/carrier_services/' . $carrierServiceId . '.json', array('carrier_service' => $carrierService->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/carrier_services/' . $carrierServiceId . '.json', array('carrier_service' => $carrierService->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('carrier_service'));
     }
@@ -57,7 +57,7 @@ class CarrierServiceEndpoint extends AbstractEndpoint
      */
     public function delete($carrierServiceId)
     {
-        $request = new DeleteParams('/admin/carrier_services/' . $carrierServiceId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/carrier_services/' . $carrierServiceId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CheckoutEndpoint.php
+++ b/src/Api/Endpoint/CheckoutEndpoint.php
@@ -7,12 +7,13 @@ class CheckoutEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|GenericEntity[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/checkouts.json', $query);
-        $response = $this->sendPaged($request, 'checkouts');
+        $response = $this->sendPaged($request, 'checkouts', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/CheckoutEndpoint.php
+++ b/src/Api/Endpoint/CheckoutEndpoint.php
@@ -11,7 +11,7 @@ class CheckoutEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/checkouts.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/checkouts.json', $query);
         $response = $this->sendPaged($request, 'checkouts');
         return $this->createCollection($response);
     }
@@ -22,7 +22,7 @@ class CheckoutEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/checkouts/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/checkouts/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }

--- a/src/Api/Endpoint/CollectEndpoint.php
+++ b/src/Api/Endpoint/CollectEndpoint.php
@@ -14,7 +14,7 @@ class CollectEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/collects.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/collects.json', $query);
         $response = $this->sendPaged($request, 'collects');
         return $this->createCollection($response);
     }
@@ -25,7 +25,7 @@ class CollectEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/collects/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/collects/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -36,7 +36,7 @@ class CollectEndpoint extends AbstractEndpoint
      */
     public function findOne($collectId)
     {
-        $request = new GetJson('/admin/collects/' . $collectId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/collects/' . $collectId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('collect'));
     }
@@ -47,7 +47,7 @@ class CollectEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $collect)
     {
-        $request = new PostJson('/admin/collects.json', array('collect' => $collect->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/collects.json', array('collect' => $collect->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('collect'));
     }
@@ -57,7 +57,7 @@ class CollectEndpoint extends AbstractEndpoint
      */
     public function delete($collectId)
     {
-        $request = new DeleteParams('/admin/collects/' . $collectId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/collects/' . $collectId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CollectEndpoint.php
+++ b/src/Api/Endpoint/CollectEndpoint.php
@@ -10,12 +10,13 @@ class CollectEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/collects.json', $query);
-        $response = $this->sendPaged($request, 'collects');
+        $response = $this->sendPaged($request, 'collects', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/CommentEndpoint.php
+++ b/src/Api/Endpoint/CommentEndpoint.php
@@ -10,12 +10,13 @@ class CommentEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/comments.json', $query);
-        $response = $this->sendPaged($request, 'comments');
+        $response = $this->sendPaged($request, 'comments', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/CommentEndpoint.php
+++ b/src/Api/Endpoint/CommentEndpoint.php
@@ -14,7 +14,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/comments.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/comments.json', $query);
         $response = $this->sendPaged($request, 'comments');
         return $this->createCollection($response);
     }
@@ -25,7 +25,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/comments/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/comments/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -36,7 +36,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function findOne($commentId)
     {
-        $request = new GetJson('/admin/comments/' . $commentId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/comments/' . $commentId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('comment'));
     }
@@ -47,7 +47,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $comment)
     {
-        $request = new PostJson('/admin/comments.json', array('comment' => $comment->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/comments.json', array('comment' => $comment->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('comment'));
     }
@@ -59,7 +59,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function update($commentId, GenericResource $comment)
     {
-        $request = new PutJson('/admin/comments/' . $commentId . '.json', array('comment' => $comment->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/comments/' . $commentId . '.json', array('comment' => $comment->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('comment'));
     }
@@ -69,7 +69,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function markAsSpam($commentId)
     {
-        $request = new PostJson('/admin/comments/' . $commentId . '/spam.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/comments/' . $commentId . '/spam.json');
         $this->send($request);
     }
 
@@ -78,7 +78,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function markAsNotSpam($commentId)
     {
-        $request = new PostJson('/admin/comments/' . $commentId . '/not_spam.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/comments/' . $commentId . '/not_spam.json');
         $this->send($request);
     }
 
@@ -87,7 +87,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function approve($commentId)
     {
-        $request = new PostJson('/admin/comments/' . $commentId . '/approve.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/comments/' . $commentId . '/approve.json');
         $this->send($request);
     }
 
@@ -96,7 +96,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function remove($commentId)
     {
-        $request = new PostJson('/admin/comments/' . $commentId . '/remove.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/comments/' . $commentId . '/remove.json');
         $this->send($request);
     }
 
@@ -105,7 +105,7 @@ class CommentEndpoint extends AbstractEndpoint
      */
     public function restore($commentId)
     {
-        $request = new PostJson('/admin/comments/' . $commentId . '/restore.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/comments/' . $commentId . '/restore.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CountryEndpoint.php
+++ b/src/Api/Endpoint/CountryEndpoint.php
@@ -14,7 +14,7 @@ class CountryEndpoint extends AbstractEndpoint
      */
     public function findAll()
     {
-        $request = new GetJson('/admin/countries.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/countries.json');
         $response = $this->send($request);
         return $this->createCollection($response->get('countries'));
     }
@@ -24,7 +24,7 @@ class CountryEndpoint extends AbstractEndpoint
      */
     public function countAll()
     {
-        $request = new GetJson('/admin/countries/count.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/countries/count.json');
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -35,7 +35,7 @@ class CountryEndpoint extends AbstractEndpoint
      */
     public function findOne($countryId)
     {
-        $request = new GetJson('/admin/countries/' . $countryId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/countries/' . $countryId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('country'));
     }
@@ -46,7 +46,7 @@ class CountryEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $country)
     {
-        $request = new PostJson('/admin/countries.json', array('country' => $country->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/countries.json', array('country' => $country->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('country'));
     }
@@ -58,7 +58,7 @@ class CountryEndpoint extends AbstractEndpoint
      */
     public function update($countryId, GenericResource $country)
     {
-        $request = new PutJson('/admin/countries/' . $countryId . '.json', array('country' => $country->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/countries/' . $countryId . '.json', array('country' => $country->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('country'));
     }
@@ -68,7 +68,7 @@ class CountryEndpoint extends AbstractEndpoint
      */
     public function delete($countryId)
     {
-        $request = new DeleteParams('/admin/countries/' . $countryId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/countries/' . $countryId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CustomCollectionEndpoint.php
+++ b/src/Api/Endpoint/CustomCollectionEndpoint.php
@@ -15,7 +15,7 @@ class CustomCollectionEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/custom_collections.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/custom_collections.json', $query);
         $response = $this->sendPaged($request, 'custom_collections');
         return $this->createCollection($response);
     }
@@ -26,7 +26,7 @@ class CustomCollectionEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/custom_collections/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/custom_collections/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -37,7 +37,7 @@ class CustomCollectionEndpoint extends AbstractEndpoint
      */
     public function findOne($customCollectionId)
     {
-        $request = new GetJson('/admin/custom_collections/' . $customCollectionId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/custom_collections/' . $customCollectionId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('custom_collection'));
     }
@@ -48,7 +48,7 @@ class CustomCollectionEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $customCollection)
     {
-        $request = new PostJson('/admin/custom_collections.json', array('custom_collection' => $customCollection->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/custom_collections.json', array('custom_collection' => $customCollection->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('custom_collection'));
     }
@@ -60,7 +60,7 @@ class CustomCollectionEndpoint extends AbstractEndpoint
      */
     public function update($customCollectionId, GenericResource $customCollection)
     {
-        $request = new PutJson('/admin/custom_collections/' . $customCollectionId . '.json', array('custom_collection' => $customCollection->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/custom_collections/' . $customCollectionId . '.json', array('custom_collection' => $customCollection->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('custom_collection'));
     }
@@ -70,7 +70,7 @@ class CustomCollectionEndpoint extends AbstractEndpoint
      */
     public function delete($customCollectionId)
     {
-        $request = new DeleteParams('/admin/custom_collections/' . $customCollectionId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/custom_collections/' . $customCollectionId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CustomCollectionEndpoint.php
+++ b/src/Api/Endpoint/CustomCollectionEndpoint.php
@@ -11,12 +11,13 @@ class CustomCollectionEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/custom_collections.json', $query);
-        $response = $this->sendPaged($request, 'custom_collections');
+        $response = $this->sendPaged($request, 'custom_collections', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/CustomerAddressEndpoint.php
+++ b/src/Api/Endpoint/CustomerAddressEndpoint.php
@@ -11,12 +11,13 @@ class CustomerAddressEndpoint extends AbstractEndpoint
 {
     /**
      * @param int $customerId
+     * @param array $links
      * @return array
      */
-    public function findByCustomer($customerId)
+    public function findByCustomer($customerId, array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/customers/' . $customerId . '.json');
-        $response = $this->sendPaged($request, 'addresses');
+        $response = $this->sendPaged($request, 'addresses', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/CustomerAddressEndpoint.php
+++ b/src/Api/Endpoint/CustomerAddressEndpoint.php
@@ -15,7 +15,7 @@ class CustomerAddressEndpoint extends AbstractEndpoint
      */
     public function findByCustomer($customerId)
     {
-        $request = new GetJson('/admin/customers/' . $customerId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/customers/' . $customerId . '.json');
         $response = $this->sendPaged($request, 'addresses');
         return $this->createCollection($response);
     }
@@ -27,7 +27,7 @@ class CustomerAddressEndpoint extends AbstractEndpoint
      */
     public function findOne($customerId, $addressId)
     {
-        $request = new GetJson('/admin/customers/' . $customerId . '/addresses/' . $addressId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/customers/' . $customerId . '/addresses/' . $addressId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('customer_address'));
     }
@@ -39,7 +39,7 @@ class CustomerAddressEndpoint extends AbstractEndpoint
      */
     public function create($customerId, GenericResource $address)
     {
-        $request = new PostJson('/admin/customers/' . $customerId . '/addresses.json', array('address' => $address->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/customers/' . $customerId . '/addresses.json', array('address' => $address->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('customer_address'));
     }
@@ -52,7 +52,7 @@ class CustomerAddressEndpoint extends AbstractEndpoint
      */
     public function update($customerId, $addressId, GenericResource $address)
     {
-        $request = new PutJson('/admin/customers/' . $customerId . '/addresses/' . $addressId . '.json', array('address' => $address->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/customers/' . $customerId . '/addresses/' . $addressId . '.json', array('address' => $address->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('customer_address'));
     }
@@ -63,7 +63,7 @@ class CustomerAddressEndpoint extends AbstractEndpoint
      */
     public function delete($customerId, $addressId)
     {
-        $request = new DeleteParams('/admin/customers/' . $customerId . '/addresses/' . $addressId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/customers/' . $customerId . '/addresses/' . $addressId . '.json');
         $this->send($request);
     }
 
@@ -82,7 +82,7 @@ class CustomerAddressEndpoint extends AbstractEndpoint
 
         $queryString[] = 'operation=' . $bulkOperation;
 
-        $request = new PutJson('/admin/customers/' . $customerId . '/addresses/set.json?' . implode('&', $queryString));
+        $request = new PutJson('/admin/api/' . $this->version . '/customers/' . $customerId . '/addresses/set.json?' . implode('&', $queryString));
         $this->send($request);
     }
 
@@ -92,7 +92,7 @@ class CustomerAddressEndpoint extends AbstractEndpoint
      */
     public function setAsDefault($customerId, $addressId)
     {
-        $request = new PutJson('/admin/customers/' . $customerId . '/addresses/' . $addressId . '/default.json');
+        $request = new PutJson('/admin/api/' . $this->version . '/customers/' . $customerId . '/addresses/' . $addressId . '/default.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CustomerEndpoint.php
+++ b/src/Api/Endpoint/CustomerEndpoint.php
@@ -11,36 +11,39 @@ class CustomerEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/customers.json', $query);
-        $response = $this->sendPaged($request, 'customers');
+        $response = $this->sendPaged($request, 'customers', $links);
         return $this->createCollection($response);
     }
 
     /**
      * @param int $customerId
      * @param array $fields
+     * @param array $links
      * @return array|GenericResource[]
      */
-    public function findOrdersForCustomer($customerId, array $fields = array())
+    public function findOrdersForCustomer($customerId, array $fields = array(), array &$links = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
         $request = new GetJson('/admin/api/' . $this->version . '/customers/' . $customerId . '.json', $params);
-        $response = $this->sendPaged($request, 'customers');
+        $response = $this->sendPaged($request, 'customers', $links);
         return $this->createCollection($response);
     }
 
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function search(array $query = array())
+    public function search(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/customers/search.json', $query);
-        $response = $this->sendPaged($request, 'customers');
+        $response = $this->sendPaged($request, 'customers', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/CustomerEndpoint.php
+++ b/src/Api/Endpoint/CustomerEndpoint.php
@@ -15,7 +15,7 @@ class CustomerEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/customers.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/customers.json', $query);
         $response = $this->sendPaged($request, 'customers');
         return $this->createCollection($response);
     }
@@ -28,7 +28,7 @@ class CustomerEndpoint extends AbstractEndpoint
     public function findOrdersForCustomer($customerId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/customers/' . $customerId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/customers/' . $customerId . '.json', $params);
         $response = $this->sendPaged($request, 'customers');
         return $this->createCollection($response);
     }
@@ -39,7 +39,7 @@ class CustomerEndpoint extends AbstractEndpoint
      */
     public function search(array $query = array())
     {
-        $request = new GetJson('/admin/customers/search.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/customers/search.json', $query);
         $response = $this->sendPaged($request, 'customers');
         return $this->createCollection($response);
     }
@@ -49,7 +49,7 @@ class CustomerEndpoint extends AbstractEndpoint
      */
     public function countAll()
     {
-        $request = new GetJson('/admin/customers/count.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/customers/count.json');
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -60,7 +60,7 @@ class CustomerEndpoint extends AbstractEndpoint
      */
     public function findOne($customerId)
     {
-        $request = new GetJson('/admin/customers/' . $customerId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/customers/' . $customerId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('customer'));
     }
@@ -71,7 +71,7 @@ class CustomerEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $customer)
     {
-        $request = new PostJson('/admin/customers.json', array('customer' => $customer->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/customers.json', array('customer' => $customer->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('customer'));
     }
@@ -83,7 +83,7 @@ class CustomerEndpoint extends AbstractEndpoint
      */
     public function update($customerId, GenericResource $customer)
     {
-        $request = new PutJson('/admin/customers/' . $customerId . '.json', array('customer' => $customer->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/customers/' . $customerId . '.json', array('customer' => $customer->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('customer'));
     }
@@ -93,7 +93,7 @@ class CustomerEndpoint extends AbstractEndpoint
      */
     public function delete($customerId)
     {
-        $request = new DeleteParams('/admin/customers/' . $customerId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/customers/' . $customerId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CustomerSavedSearchEndpoint.php
+++ b/src/Api/Endpoint/CustomerSavedSearchEndpoint.php
@@ -15,7 +15,7 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/customer_saved_searches.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/customer_saved_searches.json', $query);
         $response = $this->sendPaged($request, 'customer_saved_searches');
         return $this->createCollection($response);
     }
@@ -26,7 +26,7 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/customer_saved_searches/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/customer_saved_searches/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -39,7 +39,7 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
     public function findOne($savedSearchId, array $fields = array())
     {
         $params = $fields ? array('fields' => $fields) : array();
-        $request = new GetJson('/admin/customer_saved_searches/' . $savedSearchId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/customer_saved_searches/' . $savedSearchId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('customer_saved_search'));
     }
@@ -50,7 +50,7 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
      */
     public function findCustomersForSavedSearch($savedSearchId, array $query = array())
     {
-        $request = new GetJson('/admin/customer_saved_searches/' . $savedSearchId . '/customers.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/customer_saved_searches/' . $savedSearchId . '/customers.json', $query);
         $response = $this->sendPaged($request, 'customers');
         return $this->createCollection($response);
     }
@@ -61,7 +61,7 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $savedSearch)
     {
-        $request = new PostJson('/admin/customer_saved_searches.json', array('customer_saved_search' => $savedSearch->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/customer_saved_searches.json', array('customer_saved_search' => $savedSearch->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('customer_saved_search'));
     }
@@ -73,7 +73,7 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
      */
     public function update($savedSearchId, GenericResource $savedSearch)
     {
-        $request = new PutJson('/admin/customer_saved_searches/' . $savedSearchId . '.json', array('customer_saved_search' => $savedSearch->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/customer_saved_searches/' . $savedSearchId . '.json', array('customer_saved_search' => $savedSearch->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('customer_saved_search'));
     }
@@ -83,7 +83,7 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
      */
     public function delete($savedSearchId)
     {
-        $request = new DeleteParams('/admin/customer_saved_searches/' . $savedSearchId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/customer_saved_searches/' . $savedSearchId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/CustomerSavedSearchEndpoint.php
+++ b/src/Api/Endpoint/CustomerSavedSearchEndpoint.php
@@ -11,12 +11,13 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/customer_saved_searches.json', $query);
-        $response = $this->sendPaged($request, 'customer_saved_searches');
+        $response = $this->sendPaged($request, 'customer_saved_searches', $links);
         return $this->createCollection($response);
     }
 
@@ -46,12 +47,13 @@ class CustomerSavedSearchEndpoint extends AbstractEndpoint
 
     /**
      * @param int $savedSearchId
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findCustomersForSavedSearch($savedSearchId, array $query = array())
+    public function findCustomersForSavedSearch($savedSearchId, array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/customer_saved_searches/' . $savedSearchId . '/customers.json', $query);
-        $response = $this->sendPaged($request, 'customers');
+        $response = $this->sendPaged($request, 'customers', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/DiscountCodeEndpoint.php
+++ b/src/Api/Endpoint/DiscountCodeEndpoint.php
@@ -11,12 +11,13 @@ class DiscountCodeEndpoint extends AbstractEndpoint
 {
     /**
      * @param int $priceRuleId
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll($priceRuleId)
+    public function findAll($priceRuleId, array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '.json');
-        $response = $this->sendPaged($request, 'discount_codes');
+        $response = $this->sendPaged($request, 'discount_codes', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/DiscountCodeEndpoint.php
+++ b/src/Api/Endpoint/DiscountCodeEndpoint.php
@@ -15,7 +15,7 @@ class DiscountCodeEndpoint extends AbstractEndpoint
      */
     public function findAll($priceRuleId)
     {
-        $request = new GetJson('/admin/price_rules/' . $priceRuleId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '.json');
         $response = $this->sendPaged($request, 'discount_codes');
         return $this->createCollection($response);
     }
@@ -27,7 +27,7 @@ class DiscountCodeEndpoint extends AbstractEndpoint
      */
     public function findOne($priceRuleId, $discountCodeId)
     {
-        $request = new GetJson('/admin/price_rules/' . $priceRuleId . '/discount_codes/' . $discountCodeId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '/discount_codes/' . $discountCodeId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('price_rule'));
     }
@@ -38,7 +38,7 @@ class DiscountCodeEndpoint extends AbstractEndpoint
      */
     public function lookup($code)
     {
-        $request = new GetJson('/admin/discount_codes/lookup.json', array('code' => $code));
+        $request = new GetJson('/admin/api/' . $this->version . '/discount_codes/lookup.json', array('code' => $code));
         $response = $this->send($request);
         return $response->getHttpResponse()->getHeader('Location'); // @todo
     }
@@ -50,7 +50,7 @@ class DiscountCodeEndpoint extends AbstractEndpoint
      */
     public function create($priceRuleId, GenericResource $discountCode)
     {
-        $request = new PostJson('/admin/price_rules/' . $priceRuleId . '/discount_codes.json', array('discount_code' => $discountCode->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '/discount_codes.json', array('discount_code' => $discountCode->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('discount_code'));
     }
@@ -63,7 +63,7 @@ class DiscountCodeEndpoint extends AbstractEndpoint
      */
     public function update($priceRuleId, $discountCodeId, GenericResource $discountCode)
     {
-        $request = new PutJson('/admin/price_rules/' . $priceRuleId . '/discount_codes/' . $discountCodeId . '.json', array('discount_code' => $discountCode->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '/discount_codes/' . $discountCodeId . '.json', array('discount_code' => $discountCode->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('discount_code'));
     }
@@ -74,7 +74,7 @@ class DiscountCodeEndpoint extends AbstractEndpoint
      */
     public function delete($priceRuleId, $discountCodeId)
     {
-        $request = new DeleteParams('/admin/price_rules/' . $priceRuleId . '/discount_codes/' . $discountCodeId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '/discount_codes/' . $discountCodeId . '.json');
         $this->send($request);
     }
 

--- a/src/Api/Endpoint/DraftOrderEndpoint.php
+++ b/src/Api/Endpoint/DraftOrderEndpoint.php
@@ -11,12 +11,13 @@ class DraftOrderEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/draft_orders.json', $query);
-        $response = $this->sendPaged($request, 'draft_orders');
+        $response = $this->sendPaged($request, 'draft_orders', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/DraftOrderEndpoint.php
+++ b/src/Api/Endpoint/DraftOrderEndpoint.php
@@ -15,7 +15,7 @@ class DraftOrderEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/draft_orders.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/draft_orders.json', $query);
         $response = $this->sendPaged($request, 'draft_orders');
         return $this->createCollection($response);
     }
@@ -28,7 +28,7 @@ class DraftOrderEndpoint extends AbstractEndpoint
     public function findOne($orderId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/draft_orders/' . $orderId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/draft_orders/' . $orderId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('draft_order'));
     }
@@ -39,7 +39,7 @@ class DraftOrderEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/draft_orders/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/draft_orders/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -50,7 +50,7 @@ class DraftOrderEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $order)
     {
-        $request = new PostJson('/admin/draft_orders.json', array('draft_order' => $order->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/draft_orders.json', array('draft_order' => $order->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('draft_order'));
     }
@@ -62,7 +62,7 @@ class DraftOrderEndpoint extends AbstractEndpoint
      */
     public function update($orderId, GenericResource $order)
     {
-        $request = new PutJson('/admin/draft_orders/' . $orderId . '.json', array('draft_order' => $order->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/draft_orders/' . $orderId . '.json', array('draft_order' => $order->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('draft_order'));
     }
@@ -72,7 +72,7 @@ class DraftOrderEndpoint extends AbstractEndpoint
      */
     public function delete($orderId)
     {
-        $request = new DeleteParams('/admin/draft_orders/' . $orderId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/draft_orders/' . $orderId . '.json');
         $this->send($request);
     }
 
@@ -81,7 +81,7 @@ class DraftOrderEndpoint extends AbstractEndpoint
      */
     public function sendInvoice($orderId)
     {
-        $request = new PostJson('/admin/draft_orders/' . $orderId . '/send_invoice.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/draft_orders/' . $orderId . '/send_invoice.json');
         $this->send($request);
     }
 
@@ -91,7 +91,7 @@ class DraftOrderEndpoint extends AbstractEndpoint
      */
     public function complete($orderId, bool $paymentPending = false)
     {
-        $request = new PutJson('/admin/draft_orders/' . $orderId . '/complete.json', array('payment_pending' => $paymentPending ? 'true' : 'false'));
+        $request = new PutJson('/admin/api/' . $this->version . '/draft_orders/' . $orderId . '/complete.json', array('payment_pending' => $paymentPending ? 'true' : 'false'));
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/EventEndpoint.php
+++ b/src/Api/Endpoint/EventEndpoint.php
@@ -7,12 +7,13 @@ class EventEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|GenericEntity[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/events.json', $query);
-        $response = $this->sendPaged($request, 'events');
+        $response = $this->sendPaged($request, 'events', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/EventEndpoint.php
+++ b/src/Api/Endpoint/EventEndpoint.php
@@ -11,7 +11,7 @@ class EventEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/events.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/events.json', $query);
         $response = $this->sendPaged($request, 'events');
         return $this->createCollection($response);
     }
@@ -22,7 +22,7 @@ class EventEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/events/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/events/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -33,7 +33,7 @@ class EventEndpoint extends AbstractEndpoint
      */
     public function findOne($eventId)
     {
-        $request = new GetJson('/admin/events/' . $eventId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/events/' . $eventId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('event'));
     }

--- a/src/Api/Endpoint/FulFillmentEndpoint.php
+++ b/src/Api/Endpoint/FulFillmentEndpoint.php
@@ -15,7 +15,7 @@ class FulFillmentEndpoint extends AbstractEndpoint
      */
     public function findByOrder($orderId, array $query = array())
     {
-        $request = new GetJson('/admin/orders/' . $orderId . '/fulfillments.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/fulfillments.json', $query);
         $response = $this->sendPaged($request, 'fulfillments');
         return $this->createCollection($response);
     }
@@ -27,7 +27,7 @@ class FulFillmentEndpoint extends AbstractEndpoint
      */
     public function countByOrder($orderId, array $query = array())
     {
-        $request = new GetJson('/admin/orders/' . $orderId . '/fulfillments/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/fulfillments/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -41,7 +41,7 @@ class FulFillmentEndpoint extends AbstractEndpoint
     public function findOne($orderId, $fulfillmentId, array $fields = array())
     {
         $params = $fields ? array('fields' => $fields) : array();
-        $request = new GetJson('/admin/orders/' . $orderId . '/fulfillments/' . $fulfillmentId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/fulfillments/' . $fulfillmentId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('fulfillment'));
     }
@@ -53,7 +53,7 @@ class FulFillmentEndpoint extends AbstractEndpoint
      */
     public function create($orderId, GenericResource $fulfillment)
     {
-        $request = new PostJson('/admin/orders/' . $orderId . '/fulfillments.json', array('fulfillment' => $fulfillment->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/fulfillments.json', array('fulfillment' => $fulfillment->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('fulfillment'));
     }
@@ -66,7 +66,7 @@ class FulFillmentEndpoint extends AbstractEndpoint
      */
     public function update($orderId, $fulfillmentId, GenericResource $fulfillment)
     {
-        $request = new PutJson('/admin/orders/' . $orderId . '/fulfillments/' . $fulfillmentId . '.json', array('fulfillment' => $fulfillment->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/fulfillments/' . $fulfillmentId . '.json', array('fulfillment' => $fulfillment->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('fulfillment'));
     }
@@ -77,7 +77,7 @@ class FulFillmentEndpoint extends AbstractEndpoint
      */
     public function complete($orderId, $fulfillmentId)
     {
-        $request = new PostJson('/admin/orders/' . $orderId . '/fulfillments/' . $fulfillmentId . '/complete.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/fulfillments/' . $fulfillmentId . '/complete.json');
         $this->send($request);
     }
 
@@ -87,7 +87,7 @@ class FulFillmentEndpoint extends AbstractEndpoint
      */
     public function cancel($orderId, $fulfillmentId)
     {
-        $request = new PostJson('/admin/orders/' . $orderId . '/fulfillments/' . $fulfillmentId . '/cancel.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/fulfillments/' . $fulfillmentId . '/cancel.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/FulFillmentEndpoint.php
+++ b/src/Api/Endpoint/FulFillmentEndpoint.php
@@ -11,12 +11,13 @@ class FulFillmentEndpoint extends AbstractEndpoint
     /**
      * @param int $orderId
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findByOrder($orderId, array $query = array())
+    public function findByOrder($orderId, array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/fulfillments.json', $query);
-        $response = $this->sendPaged($request, 'fulfillments');
+        $response = $this->sendPaged($request, 'fulfillments', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/FulfillmentServiceEndpoint.php
+++ b/src/Api/Endpoint/FulfillmentServiceEndpoint.php
@@ -15,7 +15,7 @@ class FulfillmentServiceEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array('scope' => 'all'))
     {
-        $request = new GetJson('/admin/fulfillment_services.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/fulfillment_services.json', $query);
         $response = $this->send($request);
         return $this->createCollection($response->get('fulfillment_services'));
     }
@@ -26,7 +26,7 @@ class FulfillmentServiceEndpoint extends AbstractEndpoint
      */
     public function findOne($fulfillmentServiceId)
     {
-        $request = new GetJson('/admin/fulfillment_services/' . $fulfillmentServiceId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/fulfillment_services/' . $fulfillmentServiceId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('fulfillment_service'));
     }
@@ -37,7 +37,7 @@ class FulfillmentServiceEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $fulfillmentService)
     {
-        $request = new PostJson('/admin/fulfillment_services.json', array('fulfillment_service' => $fulfillmentService->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/fulfillment_services.json', array('fulfillment_service' => $fulfillmentService->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('fulfillment_service'));
     }
@@ -49,7 +49,7 @@ class FulfillmentServiceEndpoint extends AbstractEndpoint
      */
     public function update($fulfillmentServiceId, GenericResource $fulfillmentService)
     {
-        $request = new PutJson('/admin/fulfillment_services/' . $fulfillmentServiceId . '.json', array('fulfillment_service' => $fulfillmentService->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/fulfillment_services/' . $fulfillmentServiceId . '.json', array('fulfillment_service' => $fulfillmentService->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('fulfillment_service'));
     }
@@ -59,7 +59,7 @@ class FulfillmentServiceEndpoint extends AbstractEndpoint
      */
     public function delete($fulfillmentServiceId)
     {
-        $request = new DeleteParams('/admin/fulfillment_services/' . $fulfillmentServiceId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/fulfillment_services/' . $fulfillmentServiceId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/LocationEndpoint.php
+++ b/src/Api/Endpoint/LocationEndpoint.php
@@ -10,7 +10,7 @@ class LocationEndpoint extends AbstractEndpoint
      */
     public function findAll()
     {
-        $request = new GetJson('/admin/locations.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/locations.json');
         $response = $this->send($request);
         return $this->createCollection($response->get('locations'));
     }
@@ -21,7 +21,7 @@ class LocationEndpoint extends AbstractEndpoint
      */
     public function findOne($locationId)
     {
-        $request = new GetJson('/admin/locations/' . $locationId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/locations/' . $locationId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('location'));
     }

--- a/src/Api/Endpoint/MetafieldEndpoint.php
+++ b/src/Api/Endpoint/MetafieldEndpoint.php
@@ -11,32 +11,35 @@ class MetafieldEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findStoreMetafields(array $query = array())
+    public function findStoreMetafields(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/metafields.json', $query);
-        $response = $this->sendPaged($request, 'metafields');
+        $response = $this->sendPaged($request, 'metafields', $links);
         return $this->createCollection($response);
     }
 
     /**
      * @param int $productId
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findProductMetafields($productId, array $query = array())
+    public function findProductMetafields($productId, array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/metafields.json', $query);
-        $response = $this->sendPaged($request, 'metafields');
+        $response = $this->sendPaged($request, 'metafields', $links);
         return $this->createCollection($response);
     }
 
     /**
      * @param int $productImageId
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findProductImageMetafields($productImageId)
+    public function findProductImageMetafields($productImageId, array &$links = array())
     {
         $params = array(
             'metafield[owner_id]'       => $productImageId,
@@ -44,7 +47,7 @@ class MetafieldEndpoint extends AbstractEndpoint
         );
 
         $request = new GetJson('/admin/api/' . $this->version . '/metafields.json', $params);
-        $response = $this->sendPaged($request, 'metafields');
+        $response = $this->sendPaged($request, 'metafields', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/MetafieldEndpoint.php
+++ b/src/Api/Endpoint/MetafieldEndpoint.php
@@ -15,7 +15,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function findStoreMetafields(array $query = array())
     {
-        $request = new GetJson('/admin/metafields.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/metafields.json', $query);
         $response = $this->sendPaged($request, 'metafields');
         return $this->createCollection($response);
     }
@@ -27,7 +27,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function findProductMetafields($productId, array $query = array())
     {
-        $request = new GetJson('/admin/products/' . $productId . '/metafields.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/metafields.json', $query);
         $response = $this->sendPaged($request, 'metafields');
         return $this->createCollection($response);
     }
@@ -43,7 +43,7 @@ class MetafieldEndpoint extends AbstractEndpoint
             'metafield[owner_resource]' => 'product_image'
         );
 
-        $request = new GetJson('/admin/metafields.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/metafields.json', $params);
         $response = $this->sendPaged($request, 'metafields');
         return $this->createCollection($response);
     }
@@ -54,7 +54,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function findOneStoreMetafield($metafieldId)
     {
-        $request = new GetJson('/admin/metafields/' . $metafieldId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/metafields/' . $metafieldId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('metafield'));
     }
@@ -66,7 +66,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function findOneProductMetafield($metafieldId, $productId)
     {
-        $request = new GetJson('/admin/products/' . $productId . '/metafields/' . $metafieldId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/metafields/' . $metafieldId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('metafield'));
     }
@@ -76,7 +76,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function countStoreMetafields()
     {
-        $request = new GetJson('/admin/metafields/count.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/metafields/count.json');
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -87,7 +87,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function countByProduct($productId)
     {
-        $request = new GetJson('/admin/products/' . $productId . '/metafields/count.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/metafields/count.json');
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -98,7 +98,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function createStoreMetafield(GenericResource $metafield)
     {
-        $request = new PostJson('/admin/metafields.json', array('metafield' => $metafield->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/metafields.json', array('metafield' => $metafield->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('metafield'));
     }
@@ -110,7 +110,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function updateStoreMetafield($metafieldId, GenericResource $metafield)
     {
-        $request = new PutJson('/admin/metafields/' . $metafieldId . '.json', array('metafield' => $metafield->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/metafields/' . $metafieldId . '.json', array('metafield' => $metafield->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('metafield'));
     }
@@ -120,7 +120,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function deleteStoreMetafield($metafieldId)
     {
-        $request = new DeleteParams('/admin/metafields/' . $metafieldId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/metafields/' . $metafieldId . '.json');
         $this->send($request);
     }
 
@@ -131,7 +131,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function createProductMetafield($productId, GenericResource $metafield)
     {
-        $request = new PostJson('/admin/products/' . $productId . '/metafields.json', array('metafield' => $metafield->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/products/' . $productId . '/metafields.json', array('metafield' => $metafield->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('metafield'));
     }
@@ -144,7 +144,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function updateProductMetafield($metafieldId, $productId, GenericResource $metafield)
     {
-        $request = new PutJson('/admin/products/' . $productId . '/metafields/' . $metafieldId . '.json', array('metafield' => $metafield->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/products/' . $productId . '/metafields/' . $metafieldId . '.json', array('metafield' => $metafield->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('metafield'));
     }
@@ -155,7 +155,7 @@ class MetafieldEndpoint extends AbstractEndpoint
      */
     public function deleteProductMetafield($metafieldId, $productId)
     {
-        $request = new DeleteParams('/admin/products/' . $productId . '/metafields/' . $metafieldId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/products/' . $productId . '/metafields/' . $metafieldId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/OrderEndpoint.php
+++ b/src/Api/Endpoint/OrderEndpoint.php
@@ -15,7 +15,7 @@ class OrderEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/orders.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders.json', $query);
         $response = $this->sendPaged($request, 'orders');
         return $this->createCollection($response);
     }
@@ -28,7 +28,7 @@ class OrderEndpoint extends AbstractEndpoint
     public function findOne($orderId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/orders/' . $orderId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('order'));
     }
@@ -39,7 +39,7 @@ class OrderEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/orders/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -50,7 +50,7 @@ class OrderEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $order)
     {
-        $request = new PostJson('/admin/orders.json', array('order' => $order->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/orders.json', array('order' => $order->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('order'));
     }
@@ -62,7 +62,7 @@ class OrderEndpoint extends AbstractEndpoint
      */
     public function update($orderId, GenericResource $order)
     {
-        $request = new PutJson('/admin/orders/' . $orderId . '.json', array('order' => $order->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/orders/' . $orderId . '.json', array('order' => $order->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('order'));
     }
@@ -72,7 +72,7 @@ class OrderEndpoint extends AbstractEndpoint
      */
     public function delete($orderId)
     {
-        $request = new DeleteParams('/admin/orders/' . $orderId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/orders/' . $orderId . '.json');
         $this->send($request);
     }
 
@@ -81,7 +81,7 @@ class OrderEndpoint extends AbstractEndpoint
      */
     public function close($orderId)
     {
-        $request = new PostJson('/admin/orders/' . $orderId . '/close.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/close.json');
         $this->send($request);
     }
 
@@ -90,7 +90,7 @@ class OrderEndpoint extends AbstractEndpoint
      */
     public function open($orderId)
     {
-        $request = new PostJson('/admin/orders/' . $orderId . '/open.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/open.json');
         $this->send($request);
     }
 
@@ -100,7 +100,7 @@ class OrderEndpoint extends AbstractEndpoint
      */
     public function cancel($orderId, array $options = array())
     {
-        $request = new PostJson('/admin/orders/' . $orderId . '/cancel.json', $options);
+        $request = new PostJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/cancel.json', $options);
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/OrderEndpoint.php
+++ b/src/Api/Endpoint/OrderEndpoint.php
@@ -11,12 +11,13 @@ class OrderEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/orders.json', $query);
-        $response = $this->sendPaged($request, 'orders');
+        $response = $this->sendPaged($request, 'orders', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/OrderRisksEndpoint.php
+++ b/src/Api/Endpoint/OrderRisksEndpoint.php
@@ -15,7 +15,7 @@ class OrderRisksEndpoint extends AbstractEndpoint
      */
     public function findByOrder($orderId)
     {
-        $request = new GetJson('/admin/orders/' . $orderId . '/risks.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/risks.json');
         $response = $this->send($request);
         return $this->createCollection($response->get('risks'));
     }
@@ -27,7 +27,7 @@ class OrderRisksEndpoint extends AbstractEndpoint
      */
     public function findOne($orderId, $orderRisksId)
     {
-        $request = new GetJson('/admin/orders/' . $orderId . '/risks/' . $orderRisksId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/risks/' . $orderRisksId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('risk'));
     }
@@ -39,7 +39,7 @@ class OrderRisksEndpoint extends AbstractEndpoint
      */
     public function create($orderId, GenericResource $orderRisks)
     {
-        $request = new PostJson('/admin/orders/' . $orderId . '/risks.json', $orderRisks);
+        $request = new PostJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/risks.json', $orderRisks);
         $response = $this->send($request);
         return $this->createEntity($response->get('risk'));
     }
@@ -52,7 +52,7 @@ class OrderRisksEndpoint extends AbstractEndpoint
      */
     public function update($orderId, $orderRisksId, GenericResource $orderRisks)
     {
-        $request = new PutJson('/admin/orders/' . $orderId . '/risks/' . $orderRisksId . '.json', array('risk' => $orderRisks->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/risks/' . $orderRisksId . '.json', array('risk' => $orderRisks->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('risk'));
     }
@@ -63,7 +63,7 @@ class OrderRisksEndpoint extends AbstractEndpoint
      */
     public function delete($orderId, $orderRisksId)
     {
-        $request = new DeleteParams('/admin/orders/' . $orderId . '/risks/' . $orderRisksId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/orders/' . $orderId . '/risks/' . $orderRisksId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/PageEndpoint.php
+++ b/src/Api/Endpoint/PageEndpoint.php
@@ -11,12 +11,13 @@ class PageEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|GenericResource
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/pages.json', $query);
-        $response = $this->sendPaged($request, 'pages');
+        $response = $this->sendPaged($request, 'pages', $links);
         return $this->createCollection($response->get('pages'));
     }
 

--- a/src/Api/Endpoint/PageEndpoint.php
+++ b/src/Api/Endpoint/PageEndpoint.php
@@ -15,7 +15,7 @@ class PageEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/pages.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/pages.json', $query);
         $response = $this->sendPaged($request, 'pages');
         return $this->createCollection($response->get('pages'));
     }
@@ -26,7 +26,7 @@ class PageEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/pages.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/pages.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -39,7 +39,7 @@ class PageEndpoint extends AbstractEndpoint
     public function findOne($pageId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/pages/' . $pageId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/pages/' . $pageId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('page'));
     }
@@ -50,7 +50,7 @@ class PageEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $page)
     {
-        $request = new PostJson('/admin/pages.json', array('page' => $page->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/pages.json', array('page' => $page->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('page'));
     }
@@ -62,7 +62,7 @@ class PageEndpoint extends AbstractEndpoint
      */
     public function update($pageId, GenericResource $page)
     {
-        $request = new PutJson('/admin/pages/' . $pageId. '.json', array('page' => $page->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/pages/' . $pageId. '.json', array('page' => $page->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('page'));
     }
@@ -72,7 +72,7 @@ class PageEndpoint extends AbstractEndpoint
      */
     public function delete($pageId)
     {
-        $request = new DeleteParams('/admin/pages/' . $pageId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/pages/' . $pageId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/PolicyEndpoint.php
+++ b/src/Api/Endpoint/PolicyEndpoint.php
@@ -11,7 +11,7 @@ class PolicyEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/policies.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/policies.json', $query);
         $response = $this->send($request);
         return $this->createCollection($response->get('policies'));
     }

--- a/src/Api/Endpoint/PriceRuleEndpoint.php
+++ b/src/Api/Endpoint/PriceRuleEndpoint.php
@@ -11,12 +11,13 @@ class PriceRuleEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/price_rules.json', $query);
-        $response = $this->sendPaged($request, 'price_rules');
+        $response = $this->sendPaged($request, 'price_rules', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/PriceRuleEndpoint.php
+++ b/src/Api/Endpoint/PriceRuleEndpoint.php
@@ -15,7 +15,7 @@ class PriceRuleEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/price_rules.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/price_rules.json', $query);
         $response = $this->sendPaged($request, 'price_rules');
         return $this->createCollection($response);
     }
@@ -26,7 +26,7 @@ class PriceRuleEndpoint extends AbstractEndpoint
      */
     public function findOne($priceRuleId)
     {
-        $request = new GetJson('/admin/price_rules/' . $priceRuleId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('price_rule'));
     }
@@ -36,7 +36,7 @@ class PriceRuleEndpoint extends AbstractEndpoint
      */
     public function countAll()
     {
-        $request = new GetJson('/admin/price_rules/count.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/price_rules/count.json');
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -47,7 +47,7 @@ class PriceRuleEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $priceRule)
     {
-        $request = new PostJson('/admin/price_rules.json', array('price_rule' => $priceRule->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/price_rules.json', array('price_rule' => $priceRule->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('price_rule'));
     }
@@ -59,7 +59,7 @@ class PriceRuleEndpoint extends AbstractEndpoint
      */
     public function update($priceRuleId, GenericResource $priceRule)
     {
-        $request = new PutJson('/admin/price_rules/' . $priceRuleId . '.json', array('price_rule' => $priceRule->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '.json', array('price_rule' => $priceRule->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('price_rule'));
     }
@@ -69,7 +69,7 @@ class PriceRuleEndpoint extends AbstractEndpoint
      */
     public function delete($priceRuleId)
     {
-        $request = new DeleteParams('/admin/price_rules/' . $priceRuleId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/price_rules/' . $priceRuleId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/ProductEndpoint.php
+++ b/src/Api/Endpoint/ProductEndpoint.php
@@ -11,12 +11,13 @@ class ProductEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/products.json', $query);
-        $response = $this->sendPaged($request, 'products');
+        $response = $this->sendPaged($request, 'products', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/ProductEndpoint.php
+++ b/src/Api/Endpoint/ProductEndpoint.php
@@ -15,7 +15,7 @@ class ProductEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/products.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/products.json', $query);
         $response = $this->sendPaged($request, 'products');
         return $this->createCollection($response);
     }
@@ -26,7 +26,7 @@ class ProductEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/products/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/products/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -39,7 +39,7 @@ class ProductEndpoint extends AbstractEndpoint
     public function findOne($productId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/products/' . $productId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('product'));
     }
@@ -50,7 +50,7 @@ class ProductEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $product)
     {
-        $request = new PostJson('/admin/products.json', array('product' => $product->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/products.json', array('product' => $product->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('product'));
     }
@@ -62,7 +62,7 @@ class ProductEndpoint extends AbstractEndpoint
      */
     public function update($productId, GenericResource $product)
     {
-        $request = new PutJson('/admin/products/' . $productId . '.json', array('product' => $product->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/products/' . $productId . '.json', array('product' => $product->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('product'));
     }
@@ -72,7 +72,7 @@ class ProductEndpoint extends AbstractEndpoint
      */
     public function delete($productId)
     {
-        $request = new DeleteParams('/admin/products/' . $productId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/products/' . $productId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/ProductImageEndpoint.php
+++ b/src/Api/Endpoint/ProductImageEndpoint.php
@@ -16,7 +16,7 @@ class ProductImageEndpoint extends AbstractEndpoint
      */
     public function findByProduct($productId, array $query = array())
     {
-        $request = new GetJson('/admin/products/' . $productId . '/images.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/images.json', $query);
         $response = $this->send($request);
         return $this->createCollection($response->get('images'));
     }
@@ -28,7 +28,7 @@ class ProductImageEndpoint extends AbstractEndpoint
      */
     public function countByProduct($productId, array $query = array())
     {
-        $request = new GetJson('/admin/products/' . $productId . '/images/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/images/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -41,7 +41,7 @@ class ProductImageEndpoint extends AbstractEndpoint
     public function findOne($productId, $productImageId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/products/' . $productId . '/images/' . $productImageId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/images/' . $productImageId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('image'));
     }
@@ -53,7 +53,7 @@ class ProductImageEndpoint extends AbstractEndpoint
      */
     public function create($productId, GenericResource $productImage)
     {
-        $request = new PostJson('/admin/products/' . $productId . '/images.json', array('image' => $productImage->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/products/' . $productId . '/images.json', array('image' => $productImage->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('image'));
     }
@@ -66,7 +66,7 @@ class ProductImageEndpoint extends AbstractEndpoint
      */
     public function update($productId, $productImageId, GenericResource $productImage)
     {
-        $request = new PutJson('/admin/products/' . $productId . '/images/' . $productImageId . '.json', array('image' => $productImage->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/products/' . $productId . '/images/' . $productImageId . '.json', array('image' => $productImage->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('image'));
     }
@@ -77,7 +77,7 @@ class ProductImageEndpoint extends AbstractEndpoint
      */
     public function delete($productId, $productImageId)
     {
-        $request = new DeleteParams('/admin/products/' . $productId . '/images/' . $productImageId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/products/' . $productId . '/images/' . $productImageId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/ProductVariantEndpoint.php
+++ b/src/Api/Endpoint/ProductVariantEndpoint.php
@@ -16,7 +16,7 @@ class ProductVariantEndpoint extends AbstractEndpoint
      */
     public function findByProduct($productId, array $query = array())
     {
-        $request = new GetJson('/admin/products/' . $productId . '/variants.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/variants.json', $query);
         $response = $this->sendPaged($request, 'variants');
         return $this->createCollection($response);
     }
@@ -27,7 +27,7 @@ class ProductVariantEndpoint extends AbstractEndpoint
      */
     public function countByProduct($productId)
     {
-        $request = new GetJson('/admin/products/' . $productId . '/variants/count.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/variants/count.json');
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -38,7 +38,7 @@ class ProductVariantEndpoint extends AbstractEndpoint
      */
     public function findOne($variantId)
     {
-        $request = new GetJson('/admin/variants/' . $variantId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/variants/' . $variantId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('variant'));
     }
@@ -50,7 +50,7 @@ class ProductVariantEndpoint extends AbstractEndpoint
      */
     public function create($productId, GenericResource $variant)
     {
-        $request = new PostJson('/admin/products/' . $productId . '/variants.json', array('variant' => $variant->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/products/' . $productId . '/variants.json', array('variant' => $variant->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('variant'));
     }
@@ -62,7 +62,7 @@ class ProductVariantEndpoint extends AbstractEndpoint
      */
     public function update($variantId, GenericResource $variant)
     {
-        $request = new PutJson('/admin/variants/' . $variantId . '.json', array('variant' => $variant->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/variants/' . $variantId . '.json', array('variant' => $variant->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('variant'));
     }
@@ -72,7 +72,7 @@ class ProductVariantEndpoint extends AbstractEndpoint
      */
     public function delete($variantId)
     {
-        $request = new DeleteParams('/admin/variants/' . $variantId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/variants/' . $variantId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/ProductVariantEndpoint.php
+++ b/src/Api/Endpoint/ProductVariantEndpoint.php
@@ -12,12 +12,13 @@ class ProductVariantEndpoint extends AbstractEndpoint
     /**
      * @param int $productId
      * @param array $query
+     * @param array $links
      * @return array|GenericResource[]
      */
-    public function findByProduct($productId, array $query = array())
+    public function findByProduct($productId, array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/products/' . $productId . '/variants.json', $query);
-        $response = $this->sendPaged($request, 'variants');
+        $response = $this->sendPaged($request, 'variants', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/ProvinceEndpoint.php
+++ b/src/Api/Endpoint/ProvinceEndpoint.php
@@ -14,7 +14,7 @@ class ProvinceEndpoint extends AbstractEndpoint
      */
     public function findByCountry($countryId, array $query = array())
     {
-        $request = new GetJson('/admin/countries/' . $countryId . '/provinces.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/countries/' . $countryId . '/provinces.json', $query);
         $response = $this->send($request);
         return $this->createCollection($response->get('provinces'));
     }
@@ -26,7 +26,7 @@ class ProvinceEndpoint extends AbstractEndpoint
      */
     public function countByCountry($countryId, array $query = array())
     {
-        $request = new GetJson('/admin/countries/' . $countryId . '/provinces.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/countries/' . $countryId . '/provinces.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -38,7 +38,7 @@ class ProvinceEndpoint extends AbstractEndpoint
      */
     public function findOne($countryId, $provinceId)
     {
-        $request = new GetJson('/admin/countries/' . $countryId . '/provinces/' . $provinceId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/countries/' . $countryId . '/provinces/' . $provinceId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('province'));
     }
@@ -51,7 +51,7 @@ class ProvinceEndpoint extends AbstractEndpoint
      */
     public function update($countryId, $provinceId, GenericResource $province)
     {
-        $request = new PutJson('/admin/countries/' . $countryId . '/provinces/' . $provinceId . '.json', array('province' => $province->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/countries/' . $countryId . '/provinces/' . $provinceId . '.json', array('province' => $province->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('province'));
     }

--- a/src/Api/Endpoint/RecurringApplicationChargeEndpoint.php
+++ b/src/Api/Endpoint/RecurringApplicationChargeEndpoint.php
@@ -14,7 +14,7 @@ class RecurringApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $recurringApplicationCharge)
     {
-        $request = new PostJson('/admin/recurring_application_charges.json', array('recurring_application_charge' => $recurringApplicationCharge->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/recurring_application_charges.json', array('recurring_application_charge' => $recurringApplicationCharge->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('recurring_application_charge'));
     }
@@ -25,7 +25,7 @@ class RecurringApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function findOne($recurringApplicationChargeId)
     {
-        $request = new GetJson('/admin/recurring_application_charges/' . $recurringApplicationChargeId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/recurring_application_charges/' . $recurringApplicationChargeId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('recurring_application_charge'));
     }
@@ -36,7 +36,7 @@ class RecurringApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/recurring_application_charges.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/recurring_application_charges.json', $query);
         $response = $this->send($request);
         return $this->createCollection($response->get('recurring_application_charges'));
     }
@@ -47,7 +47,7 @@ class RecurringApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function activate($recurringApplicationChargeId)
     {
-        $request = new PostJson('/admin/recurring_application_charges/' . $recurringApplicationChargeId . '/activate.json');
+        $request = new PostJson('/admin/api/' . $this->version . '/recurring_application_charges/' . $recurringApplicationChargeId . '/activate.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('recurring_application_charge'));
     }
@@ -57,7 +57,7 @@ class RecurringApplicationChargeEndpoint extends AbstractEndpoint
      */
     public function delete($recurringApplicationChargeId)
     {
-        $request = new DeleteParams('/admin/recurring_application_charges/' . $recurringApplicationChargeId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/recurring_application_charges/' . $recurringApplicationChargeId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/RedirectEndpoint.php
+++ b/src/Api/Endpoint/RedirectEndpoint.php
@@ -15,7 +15,7 @@ class RedirectEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/redirects.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/redirects.json', $query);
         $response = $this->sendPaged($request, 'redirects');
         return $this->createCollection($response);
     }
@@ -26,7 +26,7 @@ class RedirectEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/redirects/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/redirects/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -39,7 +39,7 @@ class RedirectEndpoint extends AbstractEndpoint
     public function findOne($redirectId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/redirects/' . $redirectId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/redirects/' . $redirectId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('redirect'));
     }
@@ -50,7 +50,7 @@ class RedirectEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $redirect)
     {
-        $request = new PostJson('/admin/redirects.json', array('redirect' => $redirect->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/redirects.json', array('redirect' => $redirect->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('redirect'));
     }
@@ -62,7 +62,7 @@ class RedirectEndpoint extends AbstractEndpoint
      */
     public function update($redirectId, GenericResource $redirect)
     {
-        $request = new PutJson('/admin/redirects/' . $redirectId . '.json', array('redirect' => $redirect->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/redirects/' . $redirectId . '.json', array('redirect' => $redirect->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('redirect'));
     }
@@ -72,7 +72,7 @@ class RedirectEndpoint extends AbstractEndpoint
      */
     public function delete($redirectId)
     {
-        $request = new DeleteParams('/admin/redirects/' . $redirectId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/redirects/' . $redirectId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/RedirectEndpoint.php
+++ b/src/Api/Endpoint/RedirectEndpoint.php
@@ -11,12 +11,13 @@ class RedirectEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/redirects.json', $query);
-        $response = $this->sendPaged($request, 'redirects');
+        $response = $this->sendPaged($request, 'redirects', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/RefundEndpoint.php
+++ b/src/Api/Endpoint/RefundEndpoint.php
@@ -14,7 +14,7 @@ class RefundEndpoint extends AbstractEndpoint
     public function findOne($orderId, $refundId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/orders/' . $orderId . '/refunds/' . $refundId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/refunds/' . $refundId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('refund'));
     }

--- a/src/Api/Endpoint/ScriptTagEndpoint.php
+++ b/src/Api/Endpoint/ScriptTagEndpoint.php
@@ -16,7 +16,7 @@ class ScriptTagEndpoint extends AbstractEndpoint
     public function findAll(array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/script_tags.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/script_tags.json', $params);
         $response = $this->send($request);
 
         return $this->createCollection($response->get('script_tags'));
@@ -28,7 +28,7 @@ class ScriptTagEndpoint extends AbstractEndpoint
      */
     public function findOne($id)
     {
-        $request = new GetJson('/admin/script_tags/' . $id . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/script_tags/' . $id . '.json');
         $response = $this->send($request);
 
         return $this->createEntity($response->get('script_tag'));
@@ -40,7 +40,7 @@ class ScriptTagEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $resource)
     {
-        $request = new PostJson('/admin/script_tags.json', array('script_tag' => $resource->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/script_tags.json', array('script_tag' => $resource->toArray()));
         $response = $this->send($request);
 
         return $this->createEntity($response->get('script_tag'));
@@ -53,7 +53,7 @@ class ScriptTagEndpoint extends AbstractEndpoint
      */
     public function update($id, $resource)
     {
-        $request = new PutJson('/admin/script_tags/' . $id . '.json', array('script_tag' => $resource->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/script_tags/' . $id . '.json', array('script_tag' => $resource->toArray()));
         $response = $this->send($request);
 
         return $this->createEntity($response->get('script_tag'));
@@ -64,7 +64,7 @@ class ScriptTagEndpoint extends AbstractEndpoint
      */
     public function delete($id)
     {
-        $request = new DeleteParams('/admin/script_tags/' . $id . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/script_tags/' . $id . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/ShopEndpoint.php
+++ b/src/Api/Endpoint/ShopEndpoint.php
@@ -11,7 +11,7 @@ class ShopEndpoint extends AbstractEndpoint
      */
     public function findOne()
     {
-        $response = $this->send(new GetJson('/admin/shop.json'));
+        $response = $this->send(new GetJson('/admin/api/' . $this->version . '/shop.json'));
         return $this->createEntity($response->get('shop'));
     }
 }

--- a/src/Api/Endpoint/SmartCollectionEndpoint.php
+++ b/src/Api/Endpoint/SmartCollectionEndpoint.php
@@ -11,12 +11,13 @@ class SmartCollectionEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/smart_collections.json', $query);
-        $response = $this->sendPaged($request, 'smart_collections');
+        $response = $this->sendPaged($request, 'smart_collections', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/SmartCollectionEndpoint.php
+++ b/src/Api/Endpoint/SmartCollectionEndpoint.php
@@ -15,7 +15,7 @@ class SmartCollectionEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/smart_collections.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/smart_collections.json', $query);
         $response = $this->sendPaged($request, 'smart_collections');
         return $this->createCollection($response);
     }
@@ -26,7 +26,7 @@ class SmartCollectionEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/smart_collections/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/smart_collections/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -39,7 +39,7 @@ class SmartCollectionEndpoint extends AbstractEndpoint
     public function findOne($smartCollectionId, array $fields = array())
     {
         $params = $fields ? array('params' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/smart_collections/' . $smartCollectionId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/smart_collections/' . $smartCollectionId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('smart_collection'));
     }
@@ -50,7 +50,7 @@ class SmartCollectionEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $smartCollection)
     {
-        $request = new PostJson('/admin/smart_collections.json', array('smart_collection' => $smartCollection->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/smart_collections.json', array('smart_collection' => $smartCollection->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('smart_collection'));
     }
@@ -62,7 +62,7 @@ class SmartCollectionEndpoint extends AbstractEndpoint
      */
     public function update($smartCollectionId, GenericResource $smartCollection)
     {
-        $request = new PutJson('/admin/smart_collections/' . $smartCollectionId . '.json', array('smart_collection' => $smartCollection->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/smart_collections/' . $smartCollectionId . '.json', array('smart_collection' => $smartCollection->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('smart_collection'));
     }
@@ -72,7 +72,7 @@ class SmartCollectionEndpoint extends AbstractEndpoint
      */
     public function delete($smartCollectionId)
     {
-        $request = new DeleteParams('/admin/smart_collections/' . $smartCollectionId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/smart_collections/' . $smartCollectionId . '.json');
         $this->send($request);
     }
 
@@ -93,7 +93,7 @@ class SmartCollectionEndpoint extends AbstractEndpoint
             $params[] = 'products[]=' . $productId;
         }
 
-        $url = '/admin/smart_collections/' . $smartCollectionId . '/order.json' . ($params ? '?' . implode('&', $params) : '');
+        $url = '/admin/api/' . $this->version . '/smart_collections/' . $smartCollectionId . '/order.json' . ($params ? '?' . implode('&', $params) : '');
 
         $request = new PutJson($url);
         $this->send($request);

--- a/src/Api/Endpoint/ThemeEndpoint.php
+++ b/src/Api/Endpoint/ThemeEndpoint.php
@@ -16,7 +16,7 @@ class ThemeEndpoint extends AbstractEndpoint
     public function findAll(array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/themes.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/themes.json', $params);
         $response = $this->send($request);
         return $this->createCollection($response->get('themes'));
     }
@@ -29,7 +29,7 @@ class ThemeEndpoint extends AbstractEndpoint
     public function findOne($themeId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/themes/' . $themeId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/themes/' . $themeId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('theme'));
     }
@@ -40,7 +40,7 @@ class ThemeEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $theme)
     {
-        $request = new PostJson('/admin/themes.json', array('theme' => $theme->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/themes.json', array('theme' => $theme->toArray()));
         $response = $this->send($request);
         return $this->create($response->get('theme'));
     }
@@ -52,7 +52,7 @@ class ThemeEndpoint extends AbstractEndpoint
      */
     public function update($themeId, $theme)
     {
-        $request = new PutJson('/admin/themes/' . $themeId . '.json', array('theme' => $theme->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/themes/' . $themeId . '.json', array('theme' => $theme->toArray()));
         $response = $this->send($request);
         return $this->create($response->get('theme'));
     }
@@ -62,7 +62,7 @@ class ThemeEndpoint extends AbstractEndpoint
      */
     public function delete($themeId)
     {
-        $request = new DeleteParams('/admin/themes/' . $themeId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/themes/' . $themeId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/TransactionEndpoint.php
+++ b/src/Api/Endpoint/TransactionEndpoint.php
@@ -13,7 +13,7 @@ class TransactionEndpoint extends AbstractEndpoint
      */
     public function findByOrder($orderId, array $query = array())
     {
-        $request = new GetJson('/admin/orders/' . $orderId . '/transactions.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/transactions.json', $query);
         $response = $this->send($request);
         return $this->createCollection($response->get('transactions'));
     }
@@ -24,7 +24,7 @@ class TransactionEndpoint extends AbstractEndpoint
      */
     public function countByOrder($orderId)
     {
-        $request = new GetJson('/admin/orders/' . $orderId . '/transactions/count.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/transactions/count.json');
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -38,7 +38,7 @@ class TransactionEndpoint extends AbstractEndpoint
     public function findOne($orderId, $transactionId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/orders/' . $orderId . '/transactions/' . $transactionId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/transactions/' . $transactionId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('transaction'));
     }
@@ -55,7 +55,7 @@ class TransactionEndpoint extends AbstractEndpoint
             $params['amount'] = (float)$amount;
         }
 
-        $request = new PostJson('/admin/orders/' . $orderId . '/transactions.json', array('transaction' => $params));
+        $request = new PostJson('/admin/api/' . $this->version . '/orders/' . $orderId . '/transactions.json', array('transaction' => $params));
         $this->send($request);
     }
 }

--- a/src/Api/Endpoint/UserEndpoint.php
+++ b/src/Api/Endpoint/UserEndpoint.php
@@ -10,7 +10,7 @@ class UserEndpoint extends AbstractEndpoint
      */
     public function findAll()
     {
-        $request = new GetJson('/admin/users.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/users.json');
         $response = $this->send($request);
         return $this->createCollection($response->get('users'));
     }
@@ -21,7 +21,7 @@ class UserEndpoint extends AbstractEndpoint
      */
     public function findOne($userId)
     {
-        $request = new GetJson('/admin/users/' . $userId . '.json');
+        $request = new GetJson('/admin/api/' . $this->version . '/users/' . $userId . '.json');
         $response = $this->send($request);
         return $this->createEntity($response->get('user'));
     }

--- a/src/Api/Endpoint/WebhookEndpoint.php
+++ b/src/Api/Endpoint/WebhookEndpoint.php
@@ -11,12 +11,13 @@ class WebhookEndpoint extends AbstractEndpoint
 {
     /**
      * @param array $query
+     * @param array $links
      * @return array|\CodeCloud\Bundle\ShopifyBundle\Api\GenericResource[]
      */
-    public function findAll(array $query = array())
+    public function findAll(array $query = array(), array &$links = array())
     {
         $request = new GetJson('/admin/api/' . $this->version . '/webhooks.json', $query);
-        $response = $this->sendPaged($request, 'webhooks');
+        $response = $this->sendPaged($request, 'webhooks', $links);
         return $this->createCollection($response);
     }
 

--- a/src/Api/Endpoint/WebhookEndpoint.php
+++ b/src/Api/Endpoint/WebhookEndpoint.php
@@ -15,7 +15,7 @@ class WebhookEndpoint extends AbstractEndpoint
      */
     public function findAll(array $query = array())
     {
-        $request = new GetJson('/admin/webhooks.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/webhooks.json', $query);
         $response = $this->sendPaged($request, 'webhooks');
         return $this->createCollection($response);
     }
@@ -26,7 +26,7 @@ class WebhookEndpoint extends AbstractEndpoint
      */
     public function countAll(array $query = array())
     {
-        $request = new GetJson('/admin/webhooks/count.json', $query);
+        $request = new GetJson('/admin/api/' . $this->version . '/webhooks/count.json', $query);
         $response = $this->send($request);
         return $response->get('count');
     }
@@ -39,7 +39,7 @@ class WebhookEndpoint extends AbstractEndpoint
     public function findOne($webhookId, array $fields = array())
     {
         $params = $fields ? array('fields' => implode(',', $fields)) : array();
-        $request = new GetJson('/admin/webhooks/' . $webhookId . '.json', $params);
+        $request = new GetJson('/admin/api/' . $this->version . '/webhooks/' . $webhookId . '.json', $params);
         $response = $this->send($request);
         return $this->createEntity($response->get('webhook'));
     }
@@ -50,7 +50,7 @@ class WebhookEndpoint extends AbstractEndpoint
      */
     public function create(GenericResource $webhook)
     {
-        $request = new PostJson('/admin/webhooks.json', array('webhook' => $webhook->toArray()));
+        $request = new PostJson('/admin/api/' . $this->version . '/webhooks.json', array('webhook' => $webhook->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('webhook'));
     }
@@ -61,7 +61,7 @@ class WebhookEndpoint extends AbstractEndpoint
      */
     public function update($webhookId, GenericResource $webhook)
     {
-        $request = new PutJson('/admin/webhooks/' . $webhookId . '.json', array('webhook' => $webhook->toArray()));
+        $request = new PutJson('/admin/api/' . $this->version . '/webhooks/' . $webhookId . '.json', array('webhook' => $webhook->toArray()));
         $response = $this->send($request);
         return $this->createEntity($response->get('webhook'));
     }
@@ -71,7 +71,7 @@ class WebhookEndpoint extends AbstractEndpoint
      */
     public function delete($webhookId)
     {
-        $request = new DeleteParams('/admin/webhooks/' . $webhookId . '.json');
+        $request = new DeleteParams('/admin/api/' . $this->version . '/webhooks/' . $webhookId . '.json');
         $this->send($request);
     }
 }

--- a/src/Api/ShopifyApi.php
+++ b/src/Api/ShopifyApi.php
@@ -92,6 +92,11 @@ class ShopifyApi
     private $client;
 
     /**
+     * @var
+     */
+    private $version;
+
+    /**
      * @var string[]
      */
     private $endpointClasses = [
@@ -144,10 +149,12 @@ class ShopifyApi
 
     /**
      * @param ClientInterface $client
+     * @param string $version
      */
-    public function __construct(ClientInterface $client)
+    public function __construct(ClientInterface $client, string $version)
     {
         $this->client = $client;
+        $this->version = $version;
     }
 
     /**
@@ -166,7 +173,7 @@ class ShopifyApi
 
         $class = $this->endpointClasses[$endpoint];
 
-        return $this->endpoints[$endpoint] = new $class($this->client);
+        return $this->endpoints[$endpoint] = new $class($this->client, $this->version);
     }
 
     public function __get($name)

--- a/src/Api/ShopifyApiFactory.php
+++ b/src/Api/ShopifyApiFactory.php
@@ -20,15 +20,23 @@ class ShopifyApiFactory
     private $httpClientFactory;
 
     /**
+     * @var string
+     */
+    private $version;
+
+    /**
      * @param ShopifyStoreManagerInterface $storeManager
      * @param HttpClientFactoryInterface $httpClientFactory
+     * @param string $version
      */
     public function __construct(
         ShopifyStoreManagerInterface $storeManager,
-        HttpClientFactoryInterface $httpClientFactory
+        HttpClientFactoryInterface $httpClientFactory,
+        string $version
     ) {
         $this->storeManager = $storeManager;
         $this->httpClientFactory = $httpClientFactory;
+        $this->version = $version;
     }
 
     /**
@@ -40,6 +48,6 @@ class ShopifyApiFactory
         $accessToken = $this->storeManager->getAccessToken($storeName);
         $client = $this->httpClientFactory->createHttpClient($storeName, new PublicAppCredentials($accessToken));
 
-        return new ShopifyApi($client);
+        return new ShopifyApi($client, $this->version);
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -54,6 +54,7 @@ services:
       arguments:
           - "@codecloud_shopify.store_manager"
           - "@codecloud_shopify.http.client_factory"
+          - "2019-10"
 
   codecloud_shopify.signer:
       public: false


### PR DESCRIPTION
This PR provides 2019-10 API version supports.
Page-based pagination has been replaced by cursor-based pagination.