### PR TITLE
Restore compatibility with symfony 3

### DIFF
--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,14 +1,14 @@
 codecloud_shopify_auth:
     path: /shopify/auth
     defaults:
-        _controller: codecloud_shopify.controller.oauth::auth
+        _controller: codecloud_shopify.controller.oauth:auth
 
 codecloud_shopify_verify:
     path: /shopify/verify
     defaults:
-        _controller: codecloud_shopify.controller.oauth::verify
+        _controller: codecloud_shopify.controller.oauth:verify
 
 codecloud_shopify_webhooks:
     path: /shopify/webhooks
     defaults:
-        _controller: codecloud_shopify.controller.webhooks::handleWebhook
+        _controller: codecloud_shopify.controller.webhooks:handleWebhook


### PR DESCRIPTION
https://symfony.com/doc/3.3/controller/service.html
Symfony 3 requires format serviceId:method and Symfony 4 supports this format too.